### PR TITLE
Changing the local storage from SharedPreferences to Hive to demonstrate the separation of concerns

### DIFF
--- a/lib/shared/data/local/shared_prefs_storage_service.dart
+++ b/lib/shared/data/local/shared_prefs_storage_service.dart
@@ -1,49 +1,49 @@
 import 'dart:async';
-
 import 'package:flutter_project/shared/data/local/storage_service.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 
-class SharedPrefsService implements StroageService {
-  SharedPreferences? sharedPreferences;
+class HiveService implements StroageService {
+  Box? box;
 
-  final Completer<SharedPreferences> initCompleter =
-      Completer<SharedPreferences>();
+  final Completer<Box> initCompleter = Completer<Box>();
 
   @override
   void init() {
-    initCompleter.complete(SharedPreferences.getInstance());
+    initCompleter.complete(Hive.openBox('HiveService'));
   }
 
   @override
-  bool get hasInitialized => sharedPreferences != null;
+  bool get hasInitialized => initCompleter.isCompleted;
 
   @override
   Future<Object?> get(String key) async {
-    sharedPreferences = await initCompleter.future;
-    return sharedPreferences!.get(key);
+    box = await initCompleter.future;
+    return box?.get(key);
   }
 
   @override
   Future<void> clear() async {
-    sharedPreferences = await initCompleter.future;
-    await sharedPreferences!.clear();
+    box = await initCompleter.future;
+    await box?.clear();
   }
 
   @override
   Future<bool> has(String key) async {
-    sharedPreferences = await initCompleter.future;
-    return sharedPreferences?.containsKey(key) ?? false;
+    box = await initCompleter.future;
+    return box?.containsKey(key) ?? false;
   }
 
   @override
   Future<bool> remove(String key) async {
-    sharedPreferences = await initCompleter.future;
-    return await sharedPreferences!.remove(key);
+    box = await initCompleter.future;
+    await box?.delete(key);
+    return true;
   }
 
   @override
   Future<bool> set(String key, data) async {
-    sharedPreferences = await initCompleter.future;
-    return await sharedPreferences!.setString(key, data.toString());
+    box = await initCompleter.future;
+    await box?.put(key, data.toString());
+    return true;
   }
 }

--- a/lib/shared/domain/providers/sharedpreferences_storage_service_provider.dart
+++ b/lib/shared/domain/providers/sharedpreferences_storage_service_provider.dart
@@ -1,8 +1,8 @@
 import 'package:flutter_project/shared/data/local/shared_prefs_storage_service.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 
 final storageServiceProvider = Provider((ref) {
-  final SharedPrefsService prefsService = SharedPrefsService();
-  prefsService.init();
-  return prefsService;
+  Hive.initFlutter();
+  return HiveService()..init();
 });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,8 +19,10 @@ dependencies:
     sdk: flutter
   flutter_riverpod: ^2.0.2
   freezed_annotation: ^2.2.0
+  hive_flutter: ^1.1.0
   json_annotation: ^4.7.0
-  shared_preferences: ^2.0.17
+  # shared_preferences: ^2.0.17
+  path_provider: ^2.0.13
   state_notifier: ^0.7.2+1
 
 dev_dependencies:
@@ -30,6 +32,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   freezed: ^2.2.0
+  hive_test: ^1.0.1
   http_mock_adapter: ^0.3.3
   json_serializable: ^6.5.3
   mocktail: ^0.3.0


### PR DESCRIPTION
Clean architecture provides a clear separation of concerns, encourages the use of interfaces and abstractions, and facilitates changes in the dependencies without affecting the core logic of the application. 
This makes it easier to maintain, test, and extend the system over time.

With clean architecture, you can replace the SharedPreferences with Hive without affecting the core logic of the application. You would simply need to modify the data access layer, which is responsible for interacting with the data storage system. By swapping out the SharedPreferences implementation with the Hive implementation, you can change the data storage system without affecting the rest of the application.