### PR TITLE
Remove unuse nullsafety

### DIFF
--- a/lib/shared/exceptions/http_exception.dart
+++ b/lib/shared/exceptions/http_exception.dart
@@ -3,9 +3,9 @@ import 'package:flutter_project/shared/domain/models/either.dart';
 import 'package:flutter_project/shared/domain/models/response.dart';
 
 class AppException implements Exception {
-  final String? message;
-  final int? statusCode;
-  final String? identifier;
+  final String message;
+  final int statusCode;
+  final String identifier;
 
   AppException({
     required this.message,
@@ -20,13 +20,13 @@ class AppException implements Exception {
 
 class CacheFailureException extends Equatable implements AppException {
   @override
-  String? get identifier => 'Cache failure exception';
+  String get identifier => 'Cache failure exception';
 
   @override
-  String? get message => 'Unable to save user';
+  String get message => 'Unable to save user';
 
   @override
-  int? get statusCode => 100;
+  int get statusCode => 100;
 
   @override
   List<Object?> get props => [message, statusCode, identifier];


### PR DESCRIPTION
I see some null safety checks but still required in the constructor. Hope you can take a look at that issue.
![image](https://github.com/Uuttssaavv/flutter-clean-architecture-riverpod/assets/78271492/a9dbaa35-8c13-47c1-9ba1-1e8000473dff)
